### PR TITLE
Add overall comment attribute to recording model

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
   - GET `/recording/list?eid=` - `{ recordings: [<recordingObj>] }`
   - DELETE `/recording/del?rid=` - `{ data: ok }`
   - GET `/recording/get-notes?rid=` - `{ recording: [<recordingObj>] }`
-  - POST `/recording/update-notes?rid= { transcription }` - `{ recording: [<recordingObj>] }`
+  - POST `/recording/update-notes?rid= { transcription, overallComment }` - `{ recording: [<recordingObj>] }`
   - POST `/recording/mark-commented?rid=` - `{ recording: [<recordingObj>] }`
   - POST `/recording/mark-read?rid=` - `{ recording: [<recordingObj>] }`
   - GET `/recording/get-uncommented-recordings` - `{ recordings: [{ recording_id, updated_at, exercise_id, lesson_id, course_id, course_name, student_name, tutor_name }]}`

--- a/server/src/controllers/RecordingController.js
+++ b/server/src/controllers/RecordingController.js
@@ -246,7 +246,7 @@ module.exports = {
     try {
       await sequelize.transaction(async (t) => {
         const { rid } = req.query;
-        const { transcription } = req.body
+        const { transcription, overallComment } = req.body
         const recording = await Recording.findOne({
           where: {
             id: rid,
@@ -259,6 +259,9 @@ module.exports = {
           });
         }
         recording.transcription = transcription;
+        if (overallComment) {
+          recording.overallComment = overallComment;
+        }
 
         await Recording.update(recording.dataValues, {
           where: {

--- a/server/src/migrations/20201103153625-add-overallcomment-attribute-to-recording-model.js
+++ b/server/src/migrations/20201103153625-add-overallcomment-attribute-to-recording-model.js
@@ -1,0 +1,21 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.addColumn('Recordings', 'overallComment', {
+          type: Sequelize.DataTypes.STRING,
+        }, { transaction: t }),
+      ])
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    return queryInterface.sequelize.transaction(t => {
+      return Promise.all([
+        queryInterface.dropColumn('Recordings', 'overallComment', { transaction: t }),
+      ])
+    })
+  }
+};

--- a/server/src/models/Recording.js
+++ b/server/src/models/Recording.js
@@ -11,6 +11,7 @@ module.exports = (sequelize, DataTypes) => {
     audioUrl: DataTypes.STRING,
     audioFilename: DataTypes.STRING,
     transcription: DataTypes.STRING,
+    overallComment: DataTypes.STRING,
     isCommented: {
       type: DataTypes.BOOLEAN,
       defaultValue: 0


### PR DESCRIPTION
- Add overall comment attribute to recording model
- Allow (optionally) updating overall comment through `recording/update-notes` API by adding overall comment in the request body.